### PR TITLE
SSL Certificate Enforce HTTPS redirect

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -3806,6 +3806,11 @@
         }
       }
     },
+    "express-sslify": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/express-sslify/-/express-sslify-1.2.0.tgz",
+      "integrity": "sha1-MOhLzu0VV+sYdnK74UMKCioQDZw="
+    },
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",

--- a/server/package.json
+++ b/server/package.json
@@ -20,6 +20,7 @@
     "apollo-server-express": "^2.14.2",
     "cookie-parser": "^1.4.5",
     "express": "^4.17.1",
+    "express-sslify": "^1.2.0",
     "graphql": "^15.0.0",
     "mongodb": "^3.5.7",
     "mongodb-memory-server": "^6.6.1",

--- a/server/server.ts
+++ b/server/server.ts
@@ -6,6 +6,7 @@ const http = require('http');
 const mongoose = require('mongoose');
 // const cors = require('cors');
 const { v4: uuidv4 } = require('uuid');
+const enforce = require('express-sslify');
 
 const pubsub = new PubSub();
 const passport = require('passport');
@@ -225,6 +226,8 @@ if (process.env.NODE_ENV === 'production') {
     res.sendFile(path.resolve(__dirname, 'public', 'index.html'));
   });
 }
+
+app.use(enforce.HTTPS());
 
 httpServer.listen(PORT, () => {
   console.log(`🚀 Server ready at http://localhost:${PORT}${server.graphqlPath}`);


### PR DESCRIPTION
Problem: Heroku did not enforce HTTPS redirect, would redirect to HTTP.

Solution: Using express-sslify to resolve the redirect issue.